### PR TITLE
Logging dissabled

### DIFF
--- a/util.c
+++ b/util.c
@@ -609,7 +609,7 @@ typedef struct
     uint16_t window_x, window_y, window_width, window_height;
     uint16_t proxy_port;
     uint8_t proxyenable;
-    uint8_t logging_enabled : 1;
+    uint8_t logging_enabled : 0;
     uint8_t audible_notifications_enabled : 1;
     uint8_t filter : 1;
     uint8_t audio_filtering_enabled : 1;
@@ -666,7 +666,7 @@ UTOX_SAVE* config_load(void)
     save->disableudp = 0;
     save->proxy_port = 0;
     save->proxyenable = 0;
-    save->logging_enabled = 1;
+    save->logging_enabled = 0;
     save->close_to_tray = 0;
     save->start_in_tray = 0;
     save->auto_startup = 0;


### PR DESCRIPTION
New installs will no longer log conversations.
    
Logging seems inappropriate for privacy-oriented software. It is my opinion that logging is not a feature with much benefit to most users but it puts them all at risk. It also seems rude to log the words of whoever you are talking to without first asking their permission.