### PR TITLE
Dissabled logging by default #2

### DIFF
--- a/util.c
+++ b/util.c
@@ -609,7 +609,7 @@ typedef struct
     uint16_t window_x, window_y, window_width, window_height;
     uint16_t proxy_port;
     uint8_t proxyenable;
-    uint8_t logging_enabled : 1;
+    uint8_t logging_enabled : 0;
     uint8_t audible_notifications_enabled : 1;
     uint8_t filter : 1;
     uint8_t audio_filtering_enabled : 1;
@@ -669,7 +669,7 @@ UTOX_SAVE* config_load(void)
     save->proxyenable = 0;
     save->proxy_ip[0] = 0;
 
-    save->logging_enabled = 1;
+    save->logging_enabled = 0;
 
     save->close_to_tray = 0;
     save->start_in_tray = 0;


### PR DESCRIPTION
Logging does not seem appropriate for a messaging application intended for the
security minded.

I don't know what I messed up before, sorry.