### PR TITLE
make audio & video init sequential

### DIFF
--- a/tox.c
+++ b/tox.c
@@ -667,8 +667,9 @@ void tox_thread(void *UNUSED(args))
         tox_thread_init = 1;
 
         // Start the treads
-        thread(audio_thread, av);
         thread(video_thread, av);
+        while(!video_thread_init) yieldcpu(1);
+        thread(audio_thread, av);
         thread(toxav_thread, av);
 
         //


### PR DESCRIPTION
In OS X 10.9.5 I don't see the audio input devices at every ~second program start.
I think it is related to threading. The serialisation of the audio & video init fixes it.