### PR TITLE
fixed not losing focus of edit_msg when clicking the messages panel

### DIFF
--- a/ui.c
+++ b/ui.c
@@ -588,8 +588,8 @@ panel_main = {
             .disabled = 1,
             .drawfunc = draw_group,
             .child = (PANEL*[]) {
+                (void*)&edit_msg_group, // this needs to be one of the first, to get events before the others
                 (void*)&button_group_audio,
-                (void*)&edit_msg_group,
                 (void*)&scrollbar_group,
                 (void*)&messages_group,
                 (void*)&button_chat_send,
@@ -601,10 +601,11 @@ panel_main = {
             .disabled = 1,
             .drawfunc = draw_friend,
             .child = (PANEL*[]) {
+                (void*)&edit_msg, // this needs to be one of the first, to get events before the others
                 (void*)&scrollbar_friend,
                 (void*)&messages_friend,
                 (void*)&button_call_audio, (void*)&button_call_video,
-                (void*)&button_chat_left, (void*)&button_chat_right, (void*)&edit_msg, (void*)&button_chat_send,
+                (void*)&button_chat_left, (void*)&button_chat_right, (void*)&button_chat_send,
                 NULL
             }
         },

--- a/ui.c
+++ b/ui.c
@@ -588,10 +588,10 @@ panel_main = {
             .disabled = 1,
             .drawfunc = draw_group,
             .child = (PANEL*[]) {
-                (void*)&edit_msg_group, // this needs to be one of the first, to get events before the others
-                (void*)&button_group_audio,
                 (void*)&scrollbar_group,
+                (void*)&edit_msg_group, // this needs to be one of the first, to get events before the others
                 (void*)&messages_group,
+                (void*)&button_group_audio,
                 (void*)&button_chat_send,
                 NULL
             }
@@ -601,8 +601,8 @@ panel_main = {
             .disabled = 1,
             .drawfunc = draw_friend,
             .child = (PANEL*[]) {
-                (void*)&edit_msg, // this needs to be one of the first, to get events before the others
                 (void*)&scrollbar_friend,
+                (void*)&edit_msg, // this needs to be one of the first, to get events before the others
                 (void*)&messages_friend,
                 (void*)&button_call_audio, (void*)&button_call_video,
                 (void*)&button_chat_left, (void*)&button_chat_right, (void*)&button_chat_send,


### PR DESCRIPTION
This fixes selecting text in the friend message log and pressing ctrl+c to copy it.

This might have the annoying side effect of losing edit dialog focus whenever you send an inline picture or a file to a friend. If this turns out to be too much of a usability regression in practice, I recommend making these buttons explicitly return focus to the edit dialog, like the "send message" button already does(in ui_buttons.h).
