### PR TITLE
Fix Build Errors and Warnings.

### DIFF
--- a/tox.c
+++ b/tox.c
@@ -769,7 +769,7 @@ static void tox_thread_message(Tox *tox, ToxAV *av, uint64_t time, uint8_t msg,
                 postmessage(FRIEND_ACCEPT_REQUEST, (f_err != TOX_ERR_FRIEND_ADD_OK),
                                                    (f_err != TOX_ERR_FRIEND_ADD_OK) ? 0 : fid, req);
             } else {
-                debug("uTox:\tUnable to accept friend %u, error num = %i\n", req->id, fid);
+                debug("uTox:\tUnable to accept friend %u, error num = %i\n", *req->id, fid);
             }
             save_needed = 1;
             break;

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -11,6 +11,7 @@
 
 #include <X11/extensions/Xrender.h>
 #include <ft2build.h>
+#include FT_LCD_FILTER_H
 #include <fontconfig/fontconfig.h>
 #include <fontconfig/fcfreetype.h>
 
@@ -196,7 +197,7 @@ void init_ptt(void){
     if (!ptt_keyboard_handle){
         debug("Could not access ptt-kbd in data directory\n");
         ptt_display = XOpenDisplay(0);
-        XSynchronize(ptt_display, TRUE);
+        XSynchronize(ptt_display, True);
     }
 
 }


### PR DESCRIPTION
"True" is defined in Xlib.h, not "TRUE" - Causes build error.

The LCD Filter header was not included, and a pointer in a debug call
        was not dereferenced.