### PR TITLE
refactor list searching & filtering, and add previous/next tab shortcuts on Linux and Windows

### DIFF
--- a/cocoa/interaction.m
+++ b/cocoa/interaction.m
@@ -285,7 +285,6 @@ static inline void select_right_to_char(char_t c) {
     char n = 0;
     if (theEvent.charactersIgnoringModifiers.length == 1 && (theEvent.modifierFlags & NSDeviceIndependentModifierFlagsMask) == NSControlKeyMask) {
         switch (n = [theEvent.charactersIgnoringModifiers characterAtIndex:0]) {
-            case '0':
             case '1':
             case '2':
             case '3':
@@ -295,7 +294,11 @@ static inline void select_right_to_char(char_t c) {
             case '7':
             case '8':
             case '9':
-                list_selectchat(n - '0');
+                list_selectchat(n - '1');
+                redraw();
+                break;
+            case '0':
+                list_selectchat(9);
                 redraw();
                 break;
             default:

--- a/friend.c
+++ b/friend.c
@@ -177,6 +177,22 @@ void friend_addmessage(FRIEND *f, void *data) {
     }
 }
 
+_Bool friend_set_online(FRIEND *f, _Bool online) {
+    if (f->online == online) {
+        return false;
+    }
+
+    f->online = online;
+    if(!f->online) {
+        friend_set_typing(f, 0);
+    }
+
+    update_shown_list(); // update the contact list
+
+    return true;
+}
+
+
 void friend_set_typing(FRIEND *f, int typing) {
     f->typing = typing;
 }

--- a/friend.c
+++ b/friend.c
@@ -65,6 +65,8 @@ void friend_setname(FRIEND *f, char_t *name, STRING_IDX length){
         f->name_length = length;
     }
     f->name[f->name_length] = 0;
+
+    update_shown_list();
 }
 
 void friend_set_alias(FRIEND *f, char_t *alias, STRING_IDX length){
@@ -187,7 +189,7 @@ _Bool friend_set_online(FRIEND *f, _Bool online) {
         friend_set_typing(f, 0);
     }
 
-    update_shown_list(); // update the contact list
+    update_shown_list();
 
     return true;
 }

--- a/friend.h
+++ b/friend.h
@@ -44,6 +44,10 @@ void friend_recvimage(FRIEND *f, UTOX_NATIVE_IMAGE *native_image, uint16_t width
 void friend_notify(FRIEND *f, char_t *str, STRING_IDX str_length, char_t *msg, STRING_IDX msg_length);
 #define friend_notifystr(f, str, msg, mlen) friend_notify(f, (char_t*)str, sizeof(str) - 1, msg, mlen)
 void friend_addmessage_notify(FRIEND *f, char_t *data, STRING_IDX length);
+
+/* set friend online status. Returns: true if status changed, false otherwise */
+_Bool friend_set_online(FRIEND *f, _Bool online);
+
 void friend_set_typing(FRIEND *f, int typing);
 
 void friend_addid(uint8_t *id, char_t *msg, STRING_IDX msg_length);

--- a/list.c
+++ b/list.c
@@ -13,7 +13,7 @@ static uint32_t shown_list[1024]; // list of chats actually shown in the GUI aft
 static uint32_t showncount;
 
 // search and filter stuff
-static char* search_string;
+static char_t* search_string;
 static uint8_t filter;
 
 static ITEM *mouseover_item;
@@ -199,12 +199,13 @@ void list_set_filter(uint8_t new_filter) {
     update_shown_list();
 }
 
-void list_search(char *str) {
+void list_search(char_t *str) {
     search_string = str;
     update_shown_list();
 }
 
-void change_tab(int offset) {
+// change the selected item by [offset] items in the shown list
+static void change_tab(int offset) {
     if (selected_item->item == ITEM_FRIEND ||
         selected_item->item == ITEM_GROUP) {
         int index = find_item_shown_index(selected_item);

--- a/list.c
+++ b/list.c
@@ -16,12 +16,6 @@ static uint32_t showncount;
 static char* search_string;
 static uint8_t filter;
 
-
-// TODO: Update shown list function
-// TODO: Filter function
-// TODO: Search function
-// TODO: comment it all
-
 static ITEM *mouseover_item, *nitem;
 ITEM *selected_item = &item_add;
 
@@ -128,9 +122,10 @@ static void drawitem(ITEM *i, int UNUSED(x), int y) {
     }
 }
 
-static void update_shown_list(void) {
+void update_shown_list(void) {
     FRIEND *f;
-    int i, j;
+    uint32_t i; // index in item array
+    uint32_t j; // index in shown_list array
     for (i = j = 0; i < itemcount; i++) {
         ITEM *it = &item[i];
         f = it->data;
@@ -149,7 +144,6 @@ static ITEM* newitem(void) {
     ITEM *i = &item[itemcount++];
     //TODO: ..
     update_shown_list();
-    scrollbar_roster.content_height = showncount * ROSTER_BOX_HEIGHT;
     return i;
 }
 
@@ -387,9 +381,10 @@ void list_start(void) {
     }
 
     itemcount = i - item;
+
+    search_string = NULL;
     update_shown_list();
 
-    scrollbar_roster.content_height = itemcount * ROSTER_BOX_HEIGHT;
 }
 
 void list_addfriend(FRIEND *f) {
@@ -511,7 +506,6 @@ static void deleteitem(ITEM *i) {
     }
 
     itemcount--;
-    scrollbar_roster.content_height = itemcount * ROSTER_BOX_HEIGHT;
 
     int size = (&item[itemcount] - i) * sizeof(ITEM);
     memmove(i, i + 1, size);
@@ -554,7 +548,7 @@ void list_freeall(void) {
 }
 
 void list_selectchat(int index) {
-    if (index > 0 && index < showncount) {
+    if (index >= 0 && index < showncount) {
         show_page(&item[shown_list[index]]);
     }
 }

--- a/list.c
+++ b/list.c
@@ -123,6 +123,23 @@ static void drawitem(ITEM *i, int UNUSED(x), int y) {
     }
 }
 
+// find index of given item in shown_list, or INT_MAX if it can't be found
+static int find_item_shown_index(ITEM *it) {
+    int i = 0;
+    while (i < showncount) {
+        if (shown_list[i] == it - item) { // (it - item) returns the index of the item in the full items list
+            return i;
+        }
+        i++;
+    }
+    return INT_MAX; // can't be found!
+}
+
+void list_scale(void) {
+    scrollbar_roster.content_height = showncount * ROSTER_BOX_HEIGHT;
+}
+
+
 void update_shown_list(void) {
     FRIEND *f;
     uint32_t i; // index in item array
@@ -137,7 +154,7 @@ void update_shown_list(void) {
     }
 
     showncount = j;
-    scrollbar_roster.content_height = showncount * ROSTER_BOX_HEIGHT;
+    list_scale();
 }
 
 
@@ -146,10 +163,6 @@ static ITEM* newitem(void) {
     //TODO: ..
     update_shown_list();
     return i;
-}
-
-void list_scale(void) {
-    scrollbar_roster.content_height = showncount * ROSTER_BOX_HEIGHT;
 }
 
 // return item that the user is mousing over
@@ -191,20 +204,23 @@ void list_search(char *str) {
     update_shown_list();
 }
 
-void previous_tab(void) {
+void change_tab(int offset) {
     if (selected_item->item == ITEM_FRIEND ||
         selected_item->item == ITEM_GROUP) {
-        list_selectchat(0);
-        redraw();// not here
+        int index = find_item_shown_index(selected_item);
+        if (index != INT_MAX) {
+            // list_selectchat will check if out of bounds
+            list_selectchat((index + offset + showncount) % showncount);
+        }
     }
 }
 
+void previous_tab(void) {
+    change_tab(-1);
+}
+
 void next_tab(void) {
-    if (selected_item->item == ITEM_FRIEND ||
-        selected_item->item == ITEM_GROUP) {
-        list_selectchat(1);
-        redraw();// not here
-    }
+    change_tab(1);
 }
 
 
@@ -568,18 +584,6 @@ void list_selectaddfriend(void) {
 
 void list_selectswap(void) {
     show_page(&item_transfer);
-}
-
-// find index of given item in shown_list, or INT_MAX if it can't be found
-static int find_item_shown_index(ITEM *it) {
-    int i = 0;
-    while (i < showncount) {
-        if (shown_list[i] == it - item) { // (it - item) returns the index of the item in the full items list
-            return i;
-        }
-        i++;
-    }
-    return INT_MAX; // can't be found!
 }
 
 _Bool list_mmove(void *UNUSED(n), int UNUSED(x), int UNUSED(y), int UNUSED(width), int height, int mx, int my, int UNUSED(dx), int dy) {

--- a/list.h
+++ b/list.h
@@ -1,14 +1,22 @@
 /* list: the contact list
  */
 
+// call to switch to previous or next friend in list
 void previous_tab(void);
 void next_tab(void);
 
+// update the shown list, should be called whenever something relevant to the filters is done
+// (like changing name, going online, etc.)
 void update_shown_list(void);
 
+// set or get current list filter. Updates list afterwards
 uint8_t list_get_filter(void);
 void list_set_filter(uint8_t filter);
-void list_search(char *str);
+
+// set the search string in the list. Disable search by setting it to NULL. Updates list afterwards
+// warning: list will just remember the pointer, it will assume you won't deallocate the memory, and it
+// won't deallocate it after setting to NULL. The string should be NULL-terminated.
+void list_search(char_t *str);
 
 
 

--- a/list.h
+++ b/list.h
@@ -1,6 +1,14 @@
 /* list: the contact list
  */
 
+void previous_tab(void);
+void next_tab(void);
+
+uint8_t list_get_filter(void);
+void list_set_filter(uint8_t filter);
+void list_search(char *str);
+
+
 
 /* non-exhaustive list of panels we to select from, it's probably better to replace this but I don't know with what. */
 enum

--- a/list.h
+++ b/list.h
@@ -4,6 +4,8 @@
 void previous_tab(void);
 void next_tab(void);
 
+void update_shown_list(void);
+
 uint8_t list_get_filter(void);
 void list_set_filter(uint8_t filter);
 void list_search(char *str);

--- a/tox.c
+++ b/tox.c
@@ -1394,19 +1394,15 @@ void tox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void 
         }
 
         /* Friend interaction messages. */
-            /* Handshake */
+            /* Handshake
+             * param1: friend id
+             * param2: new online status(bool) */
         case FRIEND_ONLINE: {
             FRIEND *f = &friend[param1];
 
-            if (f->online == param2) {
-                break;
+            if (friend_set_online(f, param2)) {
+                redraw();
             }
-
-            f->online = param2;
-            if(!f->online) {
-                friend_set_typing(f, 0);
-            }
-            redraw();
             break;
         }
         case FRIEND_NAME: {

--- a/tox_callbacks.h
+++ b/tox_callbacks.h
@@ -104,13 +104,11 @@ static void callback_connection_status(Tox *tox, uint32_t fid, TOX_CONNECTION st
         if (friend[fid].call_state_self || friend[fid].call_state_friend) {
             utox_av_local_disconnect(NULL, fid); /* TODO HACK, toxav doesn't supply a toxav_get_toxav_from_otx() yet. */
         }
-        friend[fid].online = 0;
     } else if (!friend[fid].online && !!status) {
         ft_friend_online(tox, fid);
         /* resend avatar info (in case it changed) */
         /* Avatars must be sent LAST or they will clobber existing file transfers! */
         avatar_on_friend_online(tox, fid);
-        friend[fid].online = 1;
     }
     postmessage(FRIEND_ONLINE, fid, !!status, NULL);
 

--- a/ui.c
+++ b/ui.c
@@ -89,8 +89,8 @@ static void draw_user_badge(int UNUSED(x), int UNUSED(y), int UNUSED(width), int
     setcolor(!button_filter_friends.mouseover ? COLOR_MENU_SUBTEXT : COLOR_MAIN_HINTTEXT);
     setfont(FONT_STATUS);
     drawtextrange(SIDEBAR_FILTER_FRIENDS_LEFT, SIDEBAR_FILTER_FRIENDS_WIDTH, SIDEBAR_FILTER_FRIENDS_TOP,
-                  FILTER ? S(FILTER_ALL)    : S(FILTER_ONLINE),
-                  FILTER ? SLEN(FILTER_ALL) : SLEN(FILTER_ONLINE) );
+                  list_get_filter() ? S(FILTER_ALL)    : S(FILTER_ONLINE),
+                  list_get_filter() ? SLEN(FILTER_ALL) : SLEN(FILTER_ONLINE) );
 }
 
 /* Header for friend chat window */

--- a/ui.h
+++ b/ui.h
@@ -106,11 +106,7 @@ _Bool panel_mleave(PANEL *p);
 
 /* search
  */
-
 uint8_t SEARCH;
-uint8_t FILTER;
-int search_offset[1024];
-int search_unset[1024];
 char search_data[128];
 
 /* metrics

--- a/ui.h
+++ b/ui.h
@@ -106,7 +106,6 @@ _Bool panel_mleave(PANEL *p);
 
 /* search
  */
-uint8_t SEARCH;
 char search_data[128];
 
 /* metrics

--- a/ui.h
+++ b/ui.h
@@ -104,8 +104,6 @@ _Bool panel_mleave(PANEL *p);
 
 #define BLACK 0
 
-/* search
- */
 char search_data[128];
 
 /* metrics

--- a/ui_buttons.h
+++ b/ui_buttons.h
@@ -110,8 +110,9 @@ static void button_settings_onpress(void) {
     list_selectsettings();
 }
 
-static void button_filter_friends_mdown(void) {
-        FILTER = !FILTER;
+static void button_filter_friends_onpress(void) {
+    list_set_filter(!list_get_filter()); // this only works because right now there are only 2 filters
+                                         // (none or online), basically a bool
 }
 
 static void button_copyid_onpress(void) {
@@ -445,7 +446,7 @@ button_menu = {
 
 button_filter_friends = {
     .nodraw       = 1,
-    .onpress      = button_filter_friends_mdown,
+    .onpress      = button_filter_friends_onpress,
     .tooltip_text = { .i18nal = STR_FILTER_CONTACT_TOGGLE },
 },
 

--- a/ui_edits.h
+++ b/ui_edits.h
@@ -402,8 +402,6 @@ static void edit_search_onchange(EDIT *edit)
     STRING_IDX length = edit->length;
 
     if(!length) {
-        memset(search_offset, 0, sizeof(search_offset));
-        memset(search_unset, 0, sizeof(search_unset));
         SEARCH = 0;
     } else {
         SEARCH = 1;

--- a/ui_edits.h
+++ b/ui_edits.h
@@ -406,7 +406,7 @@ static void edit_search_onchange(EDIT *edit)
     } else {
         memcpy(search_data, data, length);
         search_data[length] = 0;
-        list_search(search_data);
+        list_search((char_t*)search_data);
     }
 
     redraw();

--- a/ui_edits.h
+++ b/ui_edits.h
@@ -402,11 +402,11 @@ static void edit_search_onchange(EDIT *edit)
     STRING_IDX length = edit->length;
 
     if(!length) {
-        SEARCH = 0;
+        list_search(NULL);
     } else {
-        SEARCH = 1;
         memcpy(search_data, data, length);
         search_data[length] = 0;
+        list_search(search_data);
     }
 
     redraw();

--- a/util.c
+++ b/util.c
@@ -704,7 +704,7 @@ NEXT:
     //dropdown_theme_onselect.selected = dropdown_theme_onselect.over = save->theme;
     dropdown_typing_notes.selected = save->no_typing_notifications;
 
-    FILTER = save->filter; /* roster list filtering */
+    list_set_filter(save->filter); /* roster list filtering */
 
     options.ipv6_enabled = save->enableipv6;
     options.udp_enabled = !save->disableudp;
@@ -768,7 +768,7 @@ void config_save(UTOX_SAVE *save)
     save->audible_notifications_enabled = audible_notifications_enabled;
     save->audio_filtering_enabled       = audio_filtering_enabled;
 
-    save->filter                        = FILTER;
+    save->filter                        = list_get_filter();
     save->proxy_port                    = options.proxy_port;
 
     save->audio_device_in               = dropdown_audio_in.selected;

--- a/windows/main.c
+++ b/windows/main.c
@@ -1631,8 +1631,10 @@ LRESULT CALLBACK WindowProc(HWND hwn, UINT msg, WPARAM wParam, LPARAM lParam)
         if(control) {
             if ((wParam == VK_TAB && shift) || wParam == VK_PRIOR) {
                 previous_tab();
+                redraw();
             } else if (wParam == VK_TAB || wParam == VK_NEXT) {
                 next_tab();
+                redraw();
             }
         }
 

--- a/windows/main.c
+++ b/windows/main.c
@@ -1619,9 +1619,16 @@ LRESULT CALLBACK WindowProc(HWND hwn, UINT msg, WPARAM wParam, LPARAM lParam)
         return 0;
     }
 
+    case WM_SYSKEYDOWN: // called instead of WM_KEYDOWN when ALT is down or F10 is pressed
     case WM_KEYDOWN: {
         _Bool control = ((GetKeyState(VK_CONTROL) & 0x80) != 0);
         _Bool shift = ((GetKeyState(VK_SHIFT) & 0x80) != 0);
+        _Bool alt = ((GetKeyState(VK_MENU) & 0x80) != 0);
+
+        if (wParam >= VK_NUMPAD0 && wParam <= VK_NUMPAD9) {
+            // normalize keypad and non-keypad numbers
+            wParam = wParam - VK_NUMPAD0 + '0';
+        }
 
         if(control && wParam == 'C') {
             copy(1);
@@ -1632,9 +1639,23 @@ LRESULT CALLBACK WindowProc(HWND hwn, UINT msg, WPARAM wParam, LPARAM lParam)
             if ((wParam == VK_TAB && shift) || wParam == VK_PRIOR) {
                 previous_tab();
                 redraw();
+                return 0;
             } else if (wParam == VK_TAB || wParam == VK_NEXT) {
                 next_tab();
                 redraw();
+                return 0;
+            }
+        }
+
+        if (control || alt) {
+            if (wParam >= '1' && wParam <= '9') {
+                list_selectchat(wParam - '1');
+                redraw();
+                return 0;
+            } else if (wParam == '0') {
+                list_selectchat(9);
+                redraw();
+                return 0;
             }
         }
 

--- a/windows/main.c
+++ b/windows/main.c
@@ -1628,6 +1628,14 @@ LRESULT CALLBACK WindowProc(HWND hwn, UINT msg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
 
+        if(control) {
+            if ((wParam == VK_TAB && shift) || wParam == VK_PRIOR) {
+                previous_tab();
+            } else if (wParam == VK_TAB || wParam == VK_NEXT) {
+                next_tab();
+            }
+        }
+
         if(edit_active()) {
             if(control) {
                 switch(wParam) {

--- a/xlib/event.c
+++ b/xlib/event.c
@@ -300,8 +300,27 @@ _Bool doevent(XEvent event)
         } else {
             len = XLookupString(ev, (char *)buffer, sizeof(buffer), &sym, NULL);
         }
+
+        // XK_ISO_Left_Tab = Shift+Tab, but we just look at whether shift is pressed
+        if (sym == XK_ISO_Left_Tab) {
+            sym = XK_Tab;
+        }
+
+        // NOTE: Don't use keys like KEY_TAB, KEY_PAGEUP, etc. from xlib/main.h here, they're
+        // overwritten by linux header linux/input.h, so they'll be different
+
+        if (ev->state & ControlMask) {
+            if ((sym == XK_Tab && (ev->state & ShiftMask)) || sym == XK_Page_Up) {
+                previous_tab();
+                break;
+            } else if (sym == XK_Tab || sym == XK_Page_Down) {
+                next_tab();
+                break;
+            }
+        }
+
         if(edit_active()) {
-            if(ev->state & 4) {
+            if(ev->state & ControlMask) {
                 switch(sym) {
                 case 'v':
                     paste();
@@ -334,10 +353,6 @@ _Bool doevent(XEvent event)
 
             if (sym == XK_KP_Enter){
                 sym = XK_Return;
-            }
-
-            if (sym == XK_ISO_Left_Tab) {
-                sym = XK_Tab;
             }
 
             if (sym == XK_Return && (ev->state & 1)) {

--- a/xlib/event.c
+++ b/xlib/event.c
@@ -312,9 +312,11 @@ _Bool doevent(XEvent event)
         if (ev->state & ControlMask) {
             if ((sym == XK_Tab && (ev->state & ShiftMask)) || sym == XK_Page_Up) {
                 previous_tab();
+                redraw();
                 break;
             } else if (sym == XK_Tab || sym == XK_Page_Down) {
                 next_tab();
+                redraw();
                 break;
             }
         }

--- a/xlib/event.c
+++ b/xlib/event.c
@@ -301,9 +301,12 @@ _Bool doevent(XEvent event)
             len = XLookupString(ev, (char *)buffer, sizeof(buffer), &sym, NULL);
         }
 
-        // XK_ISO_Left_Tab = Shift+Tab, but we just look at whether shift is pressed
         if (sym == XK_ISO_Left_Tab) {
+            // XK_ISO_Left_Tab == Shift+Tab, but we just look at whether shift is pressed
             sym = XK_Tab;
+        } else if (sym >= XK_KP_0 && sym <= XK_KP_9) {
+            // normalize keypad and non-keypad numbers
+            sym = sym - XK_KP_0 + XK_0;
         }
 
         // NOTE: Don't use keys like KEY_TAB, KEY_PAGEUP, etc. from xlib/main.h here, they're
@@ -316,6 +319,19 @@ _Bool doevent(XEvent event)
                 break;
             } else if (sym == XK_Tab || sym == XK_Page_Down) {
                 next_tab();
+                redraw();
+                break;
+            }
+        }
+
+
+        if (ev->state & ControlMask || ev->state & Mod1Mask) { // Mod1Mask == alt
+            if (sym >= XK_1 && sym <= XK_9) {
+                list_selectchat(sym - XK_1);
+                redraw();
+                break;
+            } else if (sym == XK_0) {
+                list_selectchat(9);
                 redraw();
                 break;
             }


### PR DESCRIPTION
Sorry for the amount of changes. All I wanted to do is add ctrl+[shift+]tab, ctrl+pgup and ctrl+pgdn for going through the list of friends. Then I found it wasn't easy to do with the weird way filtering and searching was implemented(would require more duplicate code as list_selectchat_filtered and list_draw already had). Also, search_offset and search_unset gave me headaches.

So this is the new system:

We still have the item list (`ITEM *item`) containing all items.
We now also have a `shown_list`, which contains indexes which point to the items from the `item` list. This is the list we use to find what items are currently visible in the user's list.
`update_shown_list()` updates our `shown_list` based on filter and search settings. It needs to be called whenever something relevant to those things is changed.
You can also use `find_item_shown_index(ITEM *it)` to get the index in the `shown_list` of given item, which is handy when for example, switching to the next or previous item in the list.

This improves things by keeping the filtering in one place(`update_shown_list()`), which creates the `shown_list` which can be used in other functions, without them having to do any filtering or use the "offsets" or "unsets" of the search. Also, we can implement something like qTox' sorting to keep online friends at the top without altering their original location with this. The disadvantage is needing to remember to call update_shown_list after anything relevant changes, but you'd only typically do that when for example adding a new filter. That doesn't happen much, and it'll be obvious that you need to update the list when working on that.

Using this system I created previous/next tab shortcuts on Linux and Windows.
TODO:
 - someone who knows Objective-C can add the shortcuts for OSX
 - make the list scroll up/down automatically when you switch to a friend not immediately visible