### PR TITLE
fixed LC_ALL not being looked at on xlib

### DIFF
--- a/xlib/main.c
+++ b/xlib/main.c
@@ -1060,7 +1060,10 @@ void config_osdefaults(UTOX_SAVE *r)
 
 static int systemlang(void)
 {
-    char *str = getenv("LC_MESSAGES");
+    char *str = getenv("LC_ALL");
+    if(!str) {
+        str = getenv("LC_MESSAGES");
+    }
     if(!str) {
         str = getenv("LANG");
     }


### PR DESCRIPTION
as spoken about on IRC, LC_ALL was being ignored when starting µTox.