### PR TITLE
do not block video device when video is not used

### DIFF
--- a/ui_dropdown.c
+++ b/ui_dropdown.c
@@ -18,17 +18,15 @@ static void dropdown_video_onselect(uint16_t i, const DROPDOWN* dm)
 {
     DROP_ELEMENT *e = &((DROP_ELEMENT*) dm->userdata)[i];
     void *handle = e->handle;
-    uint16_t b = 0;
     if(!handle && video_preview) {
+        // if no device is selected while previewing, close the preview window
         video_end(0);
         video_preview = 0;
-        b = 1; //tell video thread to stop preview too
     } else if((size_t)handle == 1) {
         desktopgrab(1);
         return;
     }
-
-    toxvideo_postmessage(VIDEO_SET, b, 0, handle);
+    toxvideo_postmessage(VIDEO_SET, 0, 0, handle);
 }
 
 static void dropdown_dpi_onselect(uint16_t i, const DROPDOWN* UNUSED(dm))

--- a/utox_av.h
+++ b/utox_av.h
@@ -25,11 +25,17 @@ enum {
 };
 
 enum {
+    // kill the video thread
     VIDEO_KILL,
+    // start a video call
     VIDEO_RECORD_START,
+    // end a video call
     VIDEO_RECORD_STOP,
+    // set a new video device
     VIDEO_SET,
+    // start a video preview
     VIDEO_PREVIEW_START,
+    // stop a video preview
     VIDEO_PREVIEW_STOP,
 };
 

--- a/video.c
+++ b/video.c
@@ -3,6 +3,7 @@
 static vpx_image_t input;
 
 static _Bool openvideodevice(void *handle) {
+    // initialize video (will populate video_width and video_height)
     if(!video_init(handle)) {
         debug("video_init() failed\n");
         return 0;
@@ -37,17 +38,26 @@ void toxvideo_postmessage(uint8_t msg, uint32_t param1, uint32_t param2, void *d
 void video_thread(void *args) {
     ToxAV *av = args;
 
+    // holds the currently selected video device
     void *video_device;
-    _Bool video_device_ready = 0,
-          video_active = 0;
+    // Whether a video device has been opened
+    _Bool video_device_open = 0;
+    // Whether video capturing is active
+    _Bool video_active = 0;
+    // counts the number of calls/previews that are currently active
     uint16_t video_count = 0;
 
     // Add always-present null video input device.
     postmessage(VIDEO_IN_DEVICE, STR_VIDEO_IN_NONE, 1, NULL);
 
+    // select a video device (autodectect)
     video_device = video_detect();
     if (video_device) {
-        video_device_ready = openvideodevice(video_device);
+        // open the video device to get some info e.g. frame size
+        // close it afterwards to not block the device while it is not used
+        if (openvideodevice(video_device)) {
+            closevideodevice(video_device);
+        }
     }
 
     video_thread_init = 1;
@@ -59,18 +69,24 @@ void video_thread(void *args) {
                 break;
             }
             switch (m->msg) {
+                // VIDEO_SET: select a different video device
                 case VIDEO_SET: {
+                    // end capturing if active
                     if (video_active) {
                         video_endread();
                     }
 
-                    if (video_device_ready) {
+                    // close the currently active video device if any
+                    if (video_device_open) {
                         closevideodevice(video_device);
+                        video_device_open = 0;
                     }
 
+                    // select the new device
                     video_device = m->data;
                     if(video_device == NULL) {
-                        video_device_ready = 0;
+                        // reset if no device is selected
+                        video_device_open = 0;
                         video_active = 0;
                         video_width = 0;
                         video_height = 0;
@@ -79,40 +95,63 @@ void video_thread(void *args) {
                         }
                     }
 
-                    video_device_ready = openvideodevice(video_device);
-                    if (video_device_ready) {
-                        if (video_count) {
+                    // directly open new device if any calls/previews are currently active
+                    if (video_count) {
+                        video_device_open = openvideodevice(video_device);
+                        if (video_device_open) {
                             video_active = video_startread();
+                        } else {
+                            // reset if opening failed
+                            video_active = 0;
+                            video_count  = 0;
                         }
                     } else {
+                        // open the video device to get some info e.g. frame size
+                        // close it afterwards to not block the device while it is not used
+                        if (openvideodevice(video_device)) {
+                            closevideodevice(video_device);
+                        }
                         video_active = 0;
-                        video_count  = 0;
                     }
 
                     debug("uToxVID:\tChanged video input device\n");
                     break;
                 }
+                // VIDEO_PREVIEW_START: a video preview has been opened
                 case VIDEO_PREVIEW_START: {
                     debug("uToxVID:\tStarting video preview\n");
                     video_preview = 1;
                 }
+                // VIDEO_RECORD_START: a video call has started
                 case VIDEO_RECORD_START: {
+                    // open device if not opended already
+                    if (video_device && !video_device_open) {
+                        video_device_open = openvideodevice(video_device);
+                    }
+                    if (!video_device_open) {
+                        debug("uToxVID:\tFailed to start video, no open video device\n");
+                        break;
+                    }
+                    // if video device is successfully opended, start capturing
                     if ( video_width && video_height ) {
                         video_count++;
                         if (video_count && !video_active) {
                             video_active = video_startread();
                         }
                     } else {
-                        debug("uTox Vid:\tCan't start video for a 0 by 0 frame\n");
+                        debug("uToxVID:\tCan't start video for a 0 by 0 frame\n");
+                        break;
                     }
                     debug("uToxVID:\tStarting video feed (%i)\n", video_count);
                     break;
                 }
+                // VIDEO_PREVIEW_STOP: a video preview has ended
                 case VIDEO_PREVIEW_STOP: {
                     debug("uToxVID:\tClosing video preview\n");
                     video_preview = 0;
                     postmessage(AV_CLOSE_WINDOW, 0, 0, NULL);
                 }
+                // VIDEO_RECORD_STOP: a video call has ended
                 case VIDEO_RECORD_STOP: {
                     video_count--;
                     debug("uToxVID:\tEnd of video record... (%i)\n", video_count);
@@ -124,7 +163,9 @@ void video_thread(void *args) {
                         debug("uToxVID:\tLast video feed close, ending read.\n");
                         video_endread();
                         video_active = 0;
-
+                        // this was the last call/preview, close the device
+                        closevideodevice(video_device);
+                        video_device_open = 0;
                     }
                     break;
                 }
@@ -133,6 +174,7 @@ void video_thread(void *args) {
         }
 
         if (video_active) {
+            // capturing is enabled, capture frames
             int r = video_getframe(utox_video_frame.y, utox_video_frame.u, utox_video_frame.v, utox_video_frame.w, utox_video_frame.h);
             if (r == 1) {
                 if (video_preview) {
@@ -175,7 +217,7 @@ void video_thread(void *args) {
                 }
             } else if(r == -1) {
                 video_active = 0;
-                video_device_ready = 0;
+                video_device_open = 0;
                 video_endread();
                 closevideodevice(video_device);
             }
@@ -188,7 +230,7 @@ void video_thread(void *args) {
         video_endread();
     }
 
-    if (video_device_ready) {
+    if (video_device_open) {
         closevideodevice(video_device);
     }
 

--- a/video.c
+++ b/video.c
@@ -88,6 +88,7 @@ void video_thread(void *args) {
                         // reset if no device is selected
                         video_device_open = 0;
                         video_active = 0;
+                        video_count = 0;
                         video_width = 0;
                         video_height = 0;
                         debug("uToxVID:\tChanged video input to NONE\n");
@@ -103,6 +104,8 @@ void video_thread(void *args) {
                             // reset if opening failed
                             video_active = 0;
                             video_count  = 0;
+                            debug("uToxVID:\tChanging video input device failed: unable to open device.\n");
+                            break;
                         }
                     } else {
                         // open the video device to get some info e.g. frame size

--- a/video.c
+++ b/video.c
@@ -90,9 +90,8 @@ void video_thread(void *args) {
                         video_active = 0;
                         video_width = 0;
                         video_height = 0;
-                        if (!m->param1) {
-                            break;
-                        }
+                        debug("uToxVID:\tChanged video input to NONE\n");
+                        break;
                     }
 
                     // directly open new device if any calls/previews are currently active


### PR DESCRIPTION
This is a rework of https://github.com/notsecure/uTox/pull/1101 on top of the new AV API.

> initially open a device when it is selected but close it afterwards to
> allow other programs to used it.
> A device is now only opened if it is actually needed, meaning either a
> preview window is opened OR a call is started.

fixes https://github.com/notsecure/uTox/issues/628