### PR TITLE
Move text from the search field to the ID field after clicking "add" instead of syncing it between both fields

### DIFF
--- a/edit.c
+++ b/edit.c
@@ -812,6 +812,10 @@ void edit_setstr(EDIT *edit, char_t *str, STRING_IDX length)
 
     edit->length = length;
     memcpy(edit->data, str, length);
+
+    if(edit->onchange) {
+        edit->onchange(edit);
+    }
 }
 
 void edit_setcursorpos(EDIT *edit, STRING_IDX pos)

--- a/ui_buttons.h
+++ b/ui_buttons.h
@@ -94,6 +94,8 @@ static void button_menu_update(BUTTON *b) {
 }
 
 static void button_add_new_contact_onpress(void) {
+    edit_setstr(&edit_add_id, (char_t *)edit_search.data, edit_search.length);
+    edit_setstr(&edit_search, (char_t *)"", 0);
     list_selectaddfriend();
 }
 

--- a/ui_buttons.h
+++ b/ui_buttons.h
@@ -97,6 +97,7 @@ static void button_add_new_contact_onpress(void) {
     edit_setstr(&edit_add_id, (char_t *)edit_search.data, edit_search.length);
     edit_setstr(&edit_search, (char_t *)"", 0);
     list_selectaddfriend();
+    edit_setfocus(&edit_add_msg);
 }
 
 static void button_create_group_onpress(void) {


### PR DESCRIPTION
Keeping the text in the search field after clicking "add" makes no sense, in most cases the user would clear the field after adding anyway. I doubt anyone would want to edit the ID from the search field when the focus is on the ID field.