### PR TITLE
Fix pointless rebuilding of uTox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ GIT_V = $(shell git describe --abbrev=8 --dirty --always --tags)
 
 all: utox
 
-utox: $(OBJ) $(OS_OBJ) tray-icon
+utox: $(OBJ) $(OS_OBJ) $(TRAY_OBJ)
 	@echo "  LD    $@"
 	@$(CC) $(CFLAGS) -o $(OUT_FILE) $(OBJ) $(OS_OBJ) $(TRAY_OBJ) $(LDFLAGS)
 
@@ -138,7 +138,7 @@ $(OS_OBJ): %.o: %.c $(HEADERS)
 	@echo "  CC    $@"
 	@$(CC) $(CFLAGS) -o $@ -c -DGIT_VERSION=\"$(GIT_V)\" $<
 
-tray-icon:
+$(TRAY_OBJ):
 	$(TRAY_GEN)
 
 clean:


### PR DESCRIPTION
The makefile uses tray-icon target instead of `$(TRAY_OBJ)`. It causes it to always rebuild, so if you do `make FILTER_AUDIO=1` + `make install` (i.e. the latter without FILTER_AUDIO as the ebuild does), make install fails because it tries to relink utox without libfilteraudio (using objects that were compiled with FILTER_AUDIO=1). To fix it's sufficient to replace both usages of `tray-icon` with `$(TRAY_OBJ)`, as does this commit.