### PR TITLE
Fix OpenBSD compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,59 +5,48 @@ V4LCONVERT = 1
 FILTER_AUDIO = 0
 UNITY = 0
 
+PKG_CONFIG ?= pkg-config
+
+OUT_FILE = utox
+
 DEPS = libtoxav libtoxcore openal vpx libsodium
 
-UNAME_S := $(shell uname -s)
-UNAME_O := $(shell uname -o)
+UNAME_S != uname -s 2>/dev/null
+UNAME_O != uname -o 2>/dev/null
 
-CFLAGS += -g -Wall -Wshadow -pthread -std=gnu99
+CFLAGS ?= -g -Wall -Wshadow
+CFLAGS += -pthread -std=gnu99
 LDFLAGS += -pthread -lm
 
-ifeq ($(FILTER_AUDIO), 1)
-	DEPS += filteraudio
-	CFLAGS += -DAUDIO_FILTERING
-endif
+DEPS += fontconfig freetype2 x11 xext xrender
+
+OS_SRC = $(wildcard src/xlib/*.c)
+OS_OBJ = $(OS_SRC:.c=.o)
+
+TRAY_OBJ = icons/utox-128x128.o
+TRAY_GEN = $(LD) -r -b binary icons/utox-128x128.png -o
 
 ifeq ($(UNAME_S), Linux)
-	OUT_FILE = utox
+CFLAGS += -DLINUX_IO
+LDFLAGS += -ldl
+endif
 
-	DEPS += fontconfig freetype2 x11 xext xrender
+ifneq ($(UNAME_S), OpenBSD)
+LDFLAGS += -lresolv
+endif
 
-	ifeq ($(V4LCONVERT), 1)
-		DEPS += libv4lconvert
-	else
-		CFLAGS += -DNO_V4LCONVERT
-	endif
+ifeq ($(UNAME_O), Cygwin)
+	DBUS = 0
+	V4LCONVERT = 0
+	FILTER_AUDIO = 0
+	UNITY = 0
 
-	ifeq ($(UNITY), 1)
-		DEPS += messaging-menu unity
-		CFLAGS += -DUNITY
-	endif
+	PKG_CONFIG := x86_64-w64-mingw32-pkg-config
 
-	ifeq ($(DBUS), 1)
-		DEPS += dbus-1
-	else
-		CFLAGS += -DNO_DBUS
-	endif
-
-	CFLAGS += $(shell pkg-config --cflags $(DEPS))
-
-	LDFLAGS += -lresolv -ldl
-	LDFLAGS += $(shell pkg-config --libs $(DEPS))
-
-	OS_SRC = $(wildcard src/xlib/*.c)
-	OS_OBJ = $(OS_SRC:.c=.o)
-
-	TRAY_OBJ = icons/utox-128x128.o
-	TRAY_GEN = $(LD) -r -b binary icons/utox-128x128.png -o
-else ifeq ($(UNAME_O), Cygwin)
 	OUT_FILE = utox.exe
 
 	CFLAGS  += -static
-	LDFLAGS += /usr/x86_64-w64-mingw32/sys-root/mingw/lib/libwinpthread.a
-
-	CFLAGS  += $(shell x86_64-w64-mingw32-pkg-config --cflags $(DEPS))
-	LDFLAGS += $(shell x86_64-w64-mingw32-pkg-config --libs   $(DEPS))
+	LDFLAGS := /usr/x86_64-w64-mingw32/sys-root/mingw/lib/libwinpthread.a
 
 	LDFLAGS += -liphlpapi -lws2_32 -lgdi32 -lmsimg32 -ldnsapi -lcomdlg32
 	LDFLAGS += -Wl,-subsystem,windows -lwinmm -lole32 -loleaut32 -lstrmiids
@@ -69,9 +58,34 @@ else ifeq ($(UNAME_O), Cygwin)
 	TRAY_GEN = x86_64-w64-mingw32-windres icons/icon.rc -O coff -o
 endif
 
+ifeq ($(DBUS), 1)
+	DEPS += dbus-1
+else
+	CFLAGS += -DNO_DBUS
+endif
+
+ifeq ($(FILTER_AUDIO), 1)
+	DEPS += filteraudio
+	CFLAGS += -DAUDIO_FILTERING
+endif
+
+ifeq ($(V4LCONVERT), 1)
+	DEPS += libv4lconvert
+else
+	CFLAGS += -DNO_V4LCONVERT
+endif
+
+ifeq ($(UNITY), 1)
+	DEPS += messaging-menu unity
+	CFLAGS += -DUNITY
+endif
+
+CFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
+LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))
 
 DESTDIR ?=
 PREFIX ?= /usr/local
+MANPREFIX ?= $(PREFIX)/share/man
 
 SRC = $(wildcard src/*.c src/png/png.c)
 HEADERS = $(wildcard src/*.h src/*/*.h)
@@ -124,7 +138,7 @@ install: utox
 	if [ "$(UNITY)" -eq "1" ]; then echo "X-MessagingMenu-UsesChatSection=true" >> $(DESTDIR)$(PREFIX)/share/applications/utox.desktop; fi
 
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
-	install -m 644 src/utox.1 $(DESTDIR)$(PREFIX)/share/man/man1/utox.1
+	install -m 644 src/utox.1 $(DESTDIR)$(MANPREFIX)/man1/utox.1
 
 $(OBJ): %.o: %.c $(HEADERS)
 	@echo "  CC    $@"

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ ifeq ($(UNITY), 1)
 	CFLAGS += -DUNITY
 endif
 
+ifeq ($V, )
+ECHO := @
+endif
+
 CFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
 LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))
 
@@ -96,7 +100,7 @@ all: utox
 
 utox: $(OBJ) $(OS_OBJ) $(TRAY_OBJ)
 	@echo "  LD    $@"
-	@$(CC) $(CFLAGS) -o $(OUT_FILE) $(OBJ) $(OS_OBJ) $(TRAY_OBJ) $(LDFLAGS)
+	$(ECHO)$(CC) $(CFLAGS) -o $(OUT_FILE) $(OBJ) $(OS_OBJ) $(TRAY_OBJ) $(LDFLAGS)
 
 install: utox
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
@@ -142,11 +146,11 @@ install: utox
 
 $(OBJ): %.o: %.c $(HEADERS)
 	@echo "  CC    $@"
-	@$(CC) $(CFLAGS) -o $@ -c -DGIT_VERSION=\"$(GIT_V)\" $<
+	$(ECHO)$(CC) $(CFLAGS) -o $@ -c -DGIT_VERSION=\"$(GIT_V)\" $<
 
 $(OS_OBJ): %.o: %.c $(HEADERS)
 	@echo "  CC    $@"
-	@$(CC) $(CFLAGS) -o $@ -c -DGIT_VERSION=\"$(GIT_V)\" $<
+	$(ECHO)$(CC) $(CFLAGS) -o $@ -c -DGIT_VERSION=\"$(GIT_V)\" $<
 
 $(TRAY_OBJ):
 	$(TRAY_GEN) $(TRAY_OBJ)

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -1,5 +1,9 @@
 #include "../main.h"
 
+#ifdef LINUX_IO
+#include <linux/input.h>
+#endif
+
 _Bool    hidden = 0;
 uint32_t tray_width = 32, tray_height = 32;
 XIC xic = NULL;
@@ -74,7 +78,6 @@ void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data)
 }
 
 
-#include <linux/input.h>
 FILE *ptt_keyboard_handle;
 Display *ptt_display;
 void init_ptt(void){
@@ -99,6 +102,7 @@ _Bool check_ptt_key(void){
     }
     int ptt_key;
 
+#ifdef LINUX_IO
     /* First, we try for direct access to the keyboard. */
     ptt_key = KEY_LEFTCTRL;                                      // TODO allow user to change this...
     if (ptt_keyboard_handle) {
@@ -117,6 +121,8 @@ _Bool check_ptt_key(void){
             return 0;
         }
     }
+#endif /* LINUX_IO */
+
     /* Okay nope, lets' fallback to xinput... *pouts*
      * Fall back to Querying the X for the current keymap. */
     ptt_key = XKeysymToKeycode(display, XK_Control_L);


### PR DESCRIPTION
In `Makefile`:

* Apply all CFLAGS and LDFLAGS configuration options unconditionally.  Platform-specific overrides may be applied on top of that.
* Don't add `-lresolv -ldl` to OpenBSD, where they are not needed.

In `src/xlib/main.c`:

* Remove Linux-specific mechanism for handling key input.  Xlib-based mechanism is portable and good enough for Linux as well.

I believe that these changes allow building uTox on other BSDs as well.