### PR TITLE
Fix application crash with variable length frame size webcams.

### DIFF
--- a/src/xlib/v4l.c
+++ b/src/xlib/v4l.c
@@ -312,7 +312,10 @@ int v4l_getframe(uint8_t *y, uint8_t *u, uint8_t *v, uint16_t width, uint16_t he
 
     /* assumes planes are continuous memory */
 #ifndef NO_V4LCONVERT
-    v4lconvert_convert(v4lconvert_data, &fmt, &dest_fmt, data, fmt.fmt.pix.sizeimage, y, (video_width * video_height * 3) / 2);
+    int result = v4lconvert_convert(v4lconvert_data, &fmt, &dest_fmt, data, buf.bytesused, y, (video_width * video_height * 3) / 2);
+    if (result == -1) {
+        debug("v4lconvert_convert error %s\n", v4lconvert_get_error_message(v4lconvert_data));
+    }
 #else
     if(fmt.fmt.pix.pixelformat == V4L2_PIX_FMT_YUYV) {
         yuv422to420(y, u, v, data, video_width, video_height);
@@ -325,5 +328,9 @@ int v4l_getframe(uint8_t *y, uint8_t *u, uint8_t *v, uint16_t width, uint16_t he
         debug("VIDIOC_QBUF error %d, %s\n", errno, strerror(errno));
     }
 
+#ifndef NO_V4LCONVERT
+    return (result == -1 ? 0 : 1);
+#else
     return 1;
+#endif
 }


### PR DESCRIPTION
For example with pac7302 cam driver and PJPG pixel format, frames
has variable length and v4lconvert_convert crash due incorrect
source size specified (sizeimage is the maximum number of bytes
required to hold an image for variable length compressed data).

Also if v4lconvert_convert will fail we must return correct value
from v4l_getframe - frame data is not valid and can not be used.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/grayhatter/utox/152)
<!-- Reviewable:end -->
