### PR TITLE
Fix OpenBSD compatibility

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,6 +19,8 @@ ifeq ($(FILTER_AUDIO), 1)
 endif
 
 ifeq ($(UNAME_S), Linux)
+	CFLAGS += -DLINUX_IO
+
 	OUT_FILE = utox
 
 	DEPS += fontconfig freetype2 x11 xext xrender

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -69,6 +69,40 @@ sudo ldconfig
 Have fun!
 
 If you're looking for a good IDE, Netbeans is very easy to setup for uTox, in fact, you can just create a new project from the existing sources and everything should work fine.
+
+
+### BSD
+
+uTox distribution includes BSD makefile, which works differently from GNU
+makefile used by GNU make.  It should work on Linux, BSDs and most other
+Unix-like systems.  Using BSD makefile allows building uTox in separate
+directory:
+```sh
+mkdir build
+cd build
+make -f path/to/uTox
+sudo make -f path/to/uTox install
+```
+*(Note: on some systems BSD make executable may not be called `make`.  Ajust
+commands accordingly.)*
+
+If needed, several concurrent builds may be performed in parallel, in different
+build directories.
+
+When called from source directory directly, BSD make will create build directory
+"build-*machine type*" automatically.
+
+Several macros (make variables) may be set to control build:
+
+* `PREFIX` (`/usr/local`), root for uTox installation.
+* `BINDIR` (`${PREFIX}/bin`), `utox` binary installation location.
+* `DATADIR` (`${PREFIX}/share/utox`), XDG application data root.
+* `MANDIR` (`${PREFIX}/share/man`), manual tree root.
+* `AUTO` (`Yes`), option dependencies autodetection toggle.
+* `OPTDEPs` (*autodetected or empty*), set of optional dependencies to use.
+  Choises are: `dbus-1`, `filteraudio`, `libv4lconvert` and `unity`.
+
+
 <a name="win" />
 ## Windows
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,159 @@
+.PHONY: all clean info install
+
+## Configuration
+
+# Separate build
+
+.for mkfile in ${MAKEFILE_LIST}
+THIS_MAKEFILE = ${mkfile}
+.endfor
+DIST = ${THIS_MAKEFILE:makefile=}
+
+# General settings
+
+PREFIX ?=		/usr/local
+BINDIR ?=		${PREFIX}/bin
+DATADIR ?=		${PREFIX}/share
+MANDIR ?=		${PREFIX}/share/man
+
+INSTALL_DATA =		install -c -m 644
+INSTALL_DATA_DIR =	install -d -m 755
+INSTALL_MAN =		install -c -m 644
+INSTALL_MAN_DIR =	install -d -m 755
+INSTALL_PROGRAM =	install -c -m 755
+INSTALL_PROGRAM_DIR =	install -d -m 755
+
+SUBDIRs =		png xlib
+SRCDIRs =		${DIST}src ${SUBDIRs:%=${DIST:Q}src/%}
+SRCs !=			find ${SRCDIRs} -maxdepth 1 -type f -name *.c
+RELSRCs =		${SRCs:S/${DIST:Q}src\///}
+OBJs =			${RELSRCs:.c=.o} utox-128x128.o
+
+ARCH !=			uname -m
+.if empty(DIST)
+BUILDDIR ?=		build-${ARCH}/
+.endif
+BIN =			${BUILDDIR}utox
+
+SIZES =			14x14 16x16 22x22 24x24 32x32 36x36 48x48 64x64 72x72 \
+			96x96 128x128 192x192 256x256 512x512
+
+CFLAGS ?=		-g -Wall -Wextra
+CFLAGS +=		-std=gnu99
+LDFLAGS +=		-pthread -lm
+
+GIT_V !=		git describe --abbrev=8 --dirty --always --tags 2> \
+			/dev/null || echo unknown
+CFLAGS +=		-DGIT_VERSION=\"${GIT_V}\"
+
+# OS-dependent linker flags
+
+OS !=			uname -s
+
+.if !empty(OS:MLinux)
+CFLAGS +=		-DLINUX_IO
+LDFLAGS +=		-ldl
+.endif
+
+.if empty(OS:MOpenBSD)
+LDFLAGS +=		-lresolv
+.endif
+
+# Dependency management
+
+DEPs =			libtoxav libtoxcore openal vpx libsodium fontconfig \
+			freetype2 x11 xext xrender
+
+AUTO ?= Yes
+.if ${AUTO:L} == yes
+OPTDEPs +!=		pkg-config dbus-1 && echo dbus-1 || echo
+OPTDEPs +!=		pkg-config filteraudio && echo filteraudio || echo
+OPTDEPs +!=		pkg-config libv4lconvert && echo libv4lconvert || echo
+OPTDEPs +!=		pkg-config unity && echo unity || echo
+.endif
+
+.if empty(OPTDEPs:Mdbus-1)
+CFLAGS +=		-DNO_DBUS
+.endif
+
+.if !empty(OPTDEPs:Mfilteraudio)
+CFLAGS +=		-DAUDIO_FILTERING
+.endif
+
+.if empty(OPTDEPs:Mlibv4lconvert)
+CFLAGS +=		-DNO_V4LCONVERT
+.endif
+
+.if !empty(OPTDEPs:Munity)
+CFLAGS +=		-DUNITY
+OPTDEPs +=		messaging-menu
+.endif
+
+CFLAGS +!=		pkg-config --cflags ${DEPs} ${OPTDEPs}
+LDFLAGS +!=		pkg-config --libs ${DEPs} ${OPTDEPs}
+
+## Build rules
+
+all: ${BIN}
+
+${SUBDIRs}:
+	@mkdir -p $@
+
+.for src in ${RELSRCs}
+${src:.c=.o}: ${DIST}src/${src}
+	${CC} ${CFLAGS} -c -o $@ ${DIST}src/${src}
+.endfor
+
+icons/utox-128x128.png:
+	@mkdir icons
+	@ln ${DIST}$@ $@ 2> /dev/null || cp ${DIST}$@ $@
+
+utox-128x128.o: icons/utox-128x128.png
+	${LD} -r -b binary -o $@ icons/utox-128x128.png
+
+utox: ${SUBDIRs} ${OBJs}
+	${CC} -o $@ ${LDFLAGS} ${OBJs}
+
+${BIN}: ${SRCs}
+	@mkdir -p ${BUILDDIR}
+	cd ${BUILDDIR}; ${MAKE} -f ${.CURDIR}/makefile
+
+## Install rules
+
+install: ${BIN}
+	${INSTALL_PROGRAM_DIR} ${BINDIR}
+	${INSTALL_PROGRAM} ${BUILDDIR}utox ${BINDIR}/utox
+	${INSTALL_DATA_DIR} ${DATADIR}
+.for size in ${SIZES}
+	${INSTALL_DATA_DIR} ${DATADIR}/icons/hicolor/${size}/apps
+	${INSTALL_DATA} ${DIST}icons/utox-${size}.png \
+	                ${DATADIR}/icons/hicolor/${size}/apps/utox.png
+.endfor
+	${INSTALL_DATA_DIR} ${DATADIR}/icons/hicolor/scalable/apps
+	${INSTALL_DATA} ${DIST}icons/utox.svg \
+	                ${DATADIR}/icons/hicolor/scalable/apps/utox.svg
+	${INSTALL_DATA_DIR} ${DATADIR}/applications
+	${INSTALL_DATA} ${DIST}src/utox.desktop \
+			${DATADIR}/applications/utox.desktop
+.if !empty(${OPTDEPs:Munity})
+	echo "X-MessagingMenu-UsesChatSection=true" >> \
+	     ${DATADIR}/applications/utox.desktop
+.endif
+	${INSTALL_MAN_DIR} ${MANDIR}/man1
+	${INSTALL_MAN} ${DIST}src/utox.1 ${MANDIR}/man1/utox.1
+
+clean:
+	@rm -rf ${BUILDDIR}
+
+info:
+	@echo "CC:            ${CC}"
+	@echo "CFLAGS:        ${CFLAGS}"
+	@echo "LDFLAGS:       ${LDFLAGS}"
+	@echo "dependencies:  ${DEPs}"
+.if ${AUTO:L} == yes
+	@echo "~ optional:    ${OPTDEPs} (autodetected)"
+.else
+	@echo "~ optional:    ${OPTDEPs}"
+.endif
+	@echo "sources:       ${SRCs}"
+	@echo "objects:       ${OBJs}"

--- a/src/xlib/main.c
+++ b/src/xlib/main.c
@@ -1,5 +1,9 @@
 #include "../main.h"
 
+#ifdef LINUX_IO
+#include <linux/input.h>
+#endif
+
 _Bool    hidden = 0;
 uint32_t tray_width = 32, tray_height = 32;
 XIC xic = NULL;
@@ -74,7 +78,6 @@ void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data)
 }
 
 
-#include <linux/input.h>
 FILE *ptt_keyboard_handle;
 Display *ptt_display;
 void init_ptt(void){
@@ -99,6 +102,7 @@ _Bool check_ptt_key(void){
     }
     int ptt_key;
 
+#ifdef LINUX_IO
     /* First, we try for direct access to the keyboard. */
     ptt_key = KEY_LEFTCTRL;                                      // TODO allow user to change this...
     if (ptt_keyboard_handle) {
@@ -117,6 +121,8 @@ _Bool check_ptt_key(void){
             return 0;
         }
     }
+#endif /* LINUX_IO */
+
     /* Okay nope, lets' fallback to xinput... *pouts*
      * Fall back to Querying the X for the current keymap. */
     ptt_key = XKeysymToKeycode(display, XK_Control_L);


### PR DESCRIPTION
I enclosed Linux-specific code in `src/xlib/main.c` inside ifdef `LINUX_IO`.
Next, I added BSD makefile under name `makefile`. BSD make looks for `makefile` first, so this name ensures that BSD make will not stumble on GNU makefile and die. GNU make looks for `GNUmakefile`, `makefile` and `Makefile`, in this order. To help it pick right makefile, I renamed `Makefile` to `GNUmakefile`.

BSD makefile allows several parallel builds are possible off the same repo, in different directories. It also provides more control over installation paths. It should be usable on Linux with `bmake`, on BSDs and (possibly) on Minix.

(Sorry for repeated pull requests - forced pushing didn't cause such problems for me before.)