### PR TITLE
Add an error check to /sendfile command

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1,9 +1,11 @@
 #include "main.h"
 
 int slash_send_file(FRIEND *friend_handle, const uint8_t *filepath){
+	if (filepath == NULL)
+		return 0;
+
     debug("Slash:\tFile path is: %s\n", filepath);
-    // todo error check on the file
-        postmessage_toxcore(TOX_FILE_SEND_NEW_SLASH, friend_handle - friend, 0xFFFF, (void*)filepath);
+    postmessage_toxcore(TOX_FILE_SEND_NEW_SLASH, friend_handle - friend, 0xFFFF, (void*)filepath);
     return 1;
 }
 


### PR DESCRIPTION
Segmentation fault occurs in tox.c when NULL pointer is dereferenced. This can be prevented by checking that user doesn't call /sendfile command without parameters