### PR TITLE
More helpful messages.

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -292,7 +292,7 @@ void theme_load(char loadtheme) {
         int size = sizeof("utox_theme.ini");
 
         if (len + size > 1024) {
-            puts("datapath too long, abandoning ship!");
+            debug("datapath too long, abandoning ship!\n");
             break;
         }
 
@@ -360,12 +360,11 @@ uint32_t try_parse_hex_colour(char *colour, int *error) {
 }
 
 void read_custom_theme(const char *path) {
-    puts("Loading custom theme:");
-    puts(path);
+    debug("Loading custom theme: %s\n", path);
 
     FILE *f = fopen(path, "r");
     if (!f) {
-        perror("error: failed to open theme");
+        debug("error: failed to open theme: %s\n", strerror(errno));
         return;
     }
 
@@ -397,11 +396,11 @@ void read_custom_theme(const char *path) {
         uint32_t col = try_parse_hex_colour(colour, &err);
 
         if (err) {
-            puts("error: parsing hex colour failed");
+            debug("error: parsing hex colour failed\n");
             continue;
         } else {
             *colourp = COLOR_PROC(col);
-            puts("set colour...");
+            debug("set colour...\n");
         }
     }
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -365,7 +365,7 @@ void read_custom_theme(const char *path) {
 
     FILE *f = fopen(path, "r");
     if (!f) {
-        perror("whad de fug DDD-xx");
+        perror("warning");
         return;
     }
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -360,12 +360,12 @@ uint32_t try_parse_hex_colour(char *colour, int *error) {
 }
 
 void read_custom_theme(const char *path) {
-    puts("hello");
+    puts("Loading custom theme:");
     puts(path);
 
     FILE *f = fopen(path, "r");
     if (!f) {
-        perror("warning");
+        perror("error: failed to open theme");
         return;
     }
 
@@ -397,7 +397,7 @@ void read_custom_theme(const char *path) {
         uint32_t col = try_parse_hex_colour(colour, &err);
 
         if (err) {
-            puts("error");
+            puts("error: parsing hex colour failed");
             continue;
         } else {
             *colourp = COLOR_PROC(col);


### PR DESCRIPTION
Some of the messages in read_custom_theme() weren't particularly helpful, change them to something more descriptive.

previously was:
> Title: Make error/warning message less offensive.
> 
> uTox prints "whad de fug DDD-xx" on console if it cannot open a file, this can be deemed offensive and unprofessional. Worst case this could hinder adoption of uTox. As uTox continues running fine afterwards change it to: "warning".
> 
> While personally this wouldn't stop me from using uTox, I don't know how others feel about it. Better safe than sorry. It seems there are some more "funny" error messages in uTox, but as they weren't offensive I left them in.