### PR TITLE
Make installation process more tunable (adjust pkg-config name and datarootdir)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ endif
 
 DESTDIR ?=
 PREFIX ?= /usr/local
+DATAROOTDIR ?= $(PREFIX)/share
 
 SRC = $(wildcard src/*.c)
 HEADERS = $(wildcard src/*.h src/*/*.h langs/*.h)
@@ -91,43 +92,43 @@ install: utox
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	install -m 0755 utox $(DESTDIR)$(PREFIX)/bin/utox
 
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/14x14/apps
-	install -m 644 icons/utox-14x14.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/14x14/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/16x16/apps
-	install -m 644 icons/utox-16x16.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/16x16/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/22x22/apps
-	install -m 644 icons/utox-22x22.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/22x22/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/24x24/apps
-	install -m 644 icons/utox-24x24.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/24x24/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/32x32/apps
-	install -m 644 icons/utox-32x32.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/32x32/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/36x36/apps
-	install -m 644 icons/utox-36x36.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/36x36/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/48x48/apps
-	install -m 644 icons/utox-48x48.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/48x48/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/64x64/apps
-	install -m 644 icons/utox-64x64.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/64x64/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/72x72/apps
-	install -m 644 icons/utox-72x72.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/72x72/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/96x96/apps
-	install -m 644 icons/utox-96x96.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/96x96/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/128x128/apps
-	install -m 644 icons/utox-128x128.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/128x128/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/192x192/apps
-	install -m 644 icons/utox-192x192.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/192x192/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/256x256/apps
-	install -m 644 icons/utox-256x256.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/256x256/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/512x512/apps
-	install -m 644 icons/utox-512x512.png $(DESTDIR)$(PREFIX)/share/icons/hicolor/512x512/apps/utox.png
-	mkdir -p $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps
-	install -m 644 icons/utox.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/utox.svg
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/14x14/apps
+	install -m 644 icons/utox-14x14.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/14x14/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/16x16/apps
+	install -m 644 icons/utox-16x16.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/16x16/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/22x22/apps
+	install -m 644 icons/utox-22x22.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/22x22/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/24x24/apps
+	install -m 644 icons/utox-24x24.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/24x24/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/32x32/apps
+	install -m 644 icons/utox-32x32.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/32x32/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/36x36/apps
+	install -m 644 icons/utox-36x36.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/36x36/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/48x48/apps
+	install -m 644 icons/utox-48x48.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/48x48/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/64x64/apps
+	install -m 644 icons/utox-64x64.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/64x64/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/72x72/apps
+	install -m 644 icons/utox-72x72.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/72x72/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/96x96/apps
+	install -m 644 icons/utox-96x96.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/96x96/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/128x128/apps
+	install -m 644 icons/utox-128x128.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/128x128/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/192x192/apps
+	install -m 644 icons/utox-192x192.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/192x192/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/256x256/apps
+	install -m 644 icons/utox-256x256.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/256x256/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/512x512/apps
+	install -m 644 icons/utox-512x512.png $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/512x512/apps/utox.png
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/scalable/apps
+	install -m 644 icons/utox.svg $(DESTDIR)$(DATAROOTDIR)/icons/hicolor/scalable/apps/utox.svg
 
-	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
-	install -m 644 src/utox.desktop $(DESTDIR)$(PREFIX)/share/applications/utox.desktop
-	if [ "$(UNITY)" -eq "1" ]; then echo "X-MessagingMenu-UsesChatSection=true" >> $(DESTDIR)$(PREFIX)/share/applications/utox.desktop; fi
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/applications
+	install -m 644 src/utox.desktop $(DESTDIR)$(DATAROOTDIR)/applications/utox.desktop
+	if [ "$(UNITY)" -eq "1" ]; then echo "X-MessagingMenu-UsesChatSection=true" >> $(DESTDIR)$(DATAROOTDIR)/applications/utox.desktop; fi
 
-	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
-	install -m 644 src/utox.1 $(DESTDIR)$(PREFIX)/share/man/man1/utox.1
+	mkdir -p $(DESTDIR)$(DATAROOTDIR)/man/man1
+	install -m 644 src/utox.1 $(DESTDIR)$(DATAROOTDIR)/man/man1/utox.1
 
 $(OBJ): %.o: %.c $(HEADERS)
 	@echo "  CC    $@"

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,12 @@ ifeq ($(UNAME_S), Linux)
 		CFLAGS += -DNO_DBUS
 	endif
 
-	CFLAGS += $(shell pkg-config --cflags $(DEPS))
+	PKG_CONFIG = pkg-config
+
+	CFLAGS += $(shell $(PKG_CONFIG) --cflags $(DEPS))
 
 	LDFLAGS += -lresolv -ldl
-	LDFLAGS += $(shell pkg-config --libs $(DEPS))
+	LDFLAGS += $(shell $(PKG_CONFIG) --libs $(DEPS))
 
 	OS_SRC = $(wildcard src/xlib/*.c)
 	OS_OBJ = $(OS_SRC:.c=.o)
@@ -56,8 +58,9 @@ else ifeq ($(UNAME_O), Cygwin)
 	CFLAGS  += -static
 	LDFLAGS += /usr/x86_64-w64-mingw32/sys-root/mingw/lib/libwinpthread.a
 
-	CFLAGS  += $(shell x86_64-w64-mingw32-pkg-config --cflags $(DEPS))
-	LDFLAGS += $(shell x86_64-w64-mingw32-pkg-config --libs   $(DEPS))
+	PKG_CONFIG = x86_64-w64-mingw32-pkg-config
+	CFLAGS  += $(shell $(PKG_CONFIG) --cflags $(DEPS))
+	LDFLAGS += $(shell $(PKG_CONFIG) --libs   $(DEPS))
 
 	LDFLAGS += -liphlpapi -lws2_32 -lgdi32 -lmsimg32 -ldnsapi -lcomdlg32
 	LDFLAGS += -Wl,-subsystem,windows -lwinmm -lole32 -loleaut32 -lstrmiids


### PR DESCRIPTION
On some platforms `pkg-config` may have cross-prefix and look like `x86_64-pc-linux-gnu-pkg-config`.

Besides that location of `datarootdir` not always is subfolder of `prefix`. In Exherbo linux filesystem layout looks like this: `/usr/x86_64-pc-linux-gnu/bin` and `/usr/share/man`. This is done intentionally to make platform-specific files placed in an individual folder for each platform while independent files can be shared in common location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grayhatter/utox/247)
<!-- Reviewable:end -->
