### PR TITLE
consistent usage of checkinstall

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -39,7 +39,7 @@ cd libsodium
 git checkout tags/1.0.3
 ./autogen.sh
 ./configure && make check
-sudo make install
+sudo checkinstall
 cd ..
 
 
@@ -55,7 +55,7 @@ cd toxcore
 autoreconf -i
 ./configure
 make
-sudo make install
+sudo checkinstall
 cd ..
 
 git clone git://github.com/GrayHatter/uTox.git

--- a/langs/hr.h
+++ b/langs/hr.h
@@ -1,0 +1,419 @@
+msgid(LANG_NATIVE_NAME)
+msgstr("hrvatski")
+
+msgid(LANG_ENGLISH_NAME)
+msgstr("Croatian")
+
+msgid(REQ_SENT)
+msgstr("Zahtjev za prijateljstvom je poslan. Kad zahtjev bude prihvaćen, kontakt će postati nazočan.")
+
+msgid(REQ_RESOLVE)
+msgstr("DNS upit u tijeku...")
+
+msgid(DNS_DISABLED)
+msgstr("DNS je onemogućen dok se rabi proxy poslužitelj bez mogućnosti slanja UDP paketa!")
+
+msgid(REQ_INVALID_ID)
+msgstr("Greška: Tox ID nije valjan")
+
+msgid(REQ_EMPTY_ID)
+msgstr("Greška: Nije naveden Tox ID")
+
+msgid(REQ_LONG_MSG)
+msgstr("Greška: Preduga poruka")
+
+msgid(REQ_NO_MSG)
+msgstr("Greška: Prazna poruka")
+
+msgid(REQ_SELF_ID)
+msgstr("Greška: Uneseni Tox ID je vaš vlastiti Tox ID")
+
+msgid(REQ_ALREADY_FRIENDS)
+msgstr("Greška: Uneseni Tox ID je već dodan u popis prijatelja")
+
+msgid(REQ_UNKNOWN)
+msgstr("Greška: Nepoznat uzrok greške")
+
+msgid(REQ_BAD_CHECKSUM)
+msgstr("Greška: Nevaljani Tox ID (nevaljani kontrolni zbroj)")
+
+msgid(REQ_BAD_NOSPAM)
+msgstr("Greška: Nevaljani Tox ID (nevaljana nospam vrijednost)")
+
+msgid(REQ_NO_MEMORY)
+msgstr("Greška: Nema slobodne memorije")
+
+msgid(SEND_FILE)
+msgstr("Pošalji datoteku")
+
+msgid(SAVE_FILE)
+msgstr("Snimi datoteku")
+
+msgid(WHERE_TO_SAVE_FILE_PROMPT)
+msgstr("Gdje želite snimiti \"%.*s\"?")
+
+msgid(WHERE_TO_SAVE_FILE)
+msgstr("Gdje želite snimiti datoteku?")
+
+msgid(SEND_FILE_PROMPT)
+msgstr("Izaberite jednu ili više datoteka za slanje.")
+
+msgid(SCREEN_CAPTURE_PROMPT)
+msgstr("Namjestite okvir oko područja ekrana koje želite poslati.")
+
+msgid(TRANSFER_NEW)
+msgstr("Novi prijenos datoteka")
+
+msgid(TRANSFER_STARTED)
+msgstr("Prijenos datoteka u tijeku")
+
+msgid(TRANSFER_PAUSED)
+msgstr("Prijenos datoteka zaustavljen")
+
+msgid(TRANSFER_BROKEN)
+msgstr("Prijenos datoteka nije uspio")
+
+msgid(TRANSFER_CANCELLED)
+msgstr("Prijenos datoteka otkazan")
+
+msgid(TRANSFER_COMPLETE)
+msgstr("Prijenos datoteka dovršen")
+
+msgid(GROUPCHAT_JOIN_AUDIO)
+msgstr("Spoji se na audio chat")
+
+msgid(START_AUDIO_CALL)
+msgstr("Nazovi")
+
+msgid(START_VIDEO_CALL)
+msgstr("Nazovi - video poziv")
+
+msgid(CALL_CANCELLED)
+msgstr("Poziv otkazan")
+
+msgid(CALL_INVITED)
+msgstr("Poziv je poslan")
+
+msgid(CALL_RINGING)
+msgstr("Zvoni")
+
+msgid(CALL_STARTED)
+msgstr("Razgovor u tijeku")
+
+msgid(PROFILE_SETTINGS)
+msgstr("Postavke profila")
+
+msgid(PROFILE_PW_WARNING)
+msgstr("UPOZORENJE: µTox će automatski početi enkriptirati s navedenom zaporkom.")
+
+msgid(PROFILE_PW_NO_RECOVER)
+msgstr("Nema načina za vraćanje zaboravljene zaporke.")
+
+msgid(ADDFRIENDS)
+msgstr("Dodaj novi kontakt")
+
+msgid(MESSAGE)
+msgstr("Poruka")
+
+msgid(SEARCHFRIENDS)
+msgstr("Traži prijatelje")
+
+msgid(FILTER_ONLINE)
+msgstr("Nazočni prijatelji")
+
+msgid(FILTER_ALL)
+msgstr("Svi prijatelji")
+
+msgid(FILTER_CONTACT_TOGGLE)
+msgstr("Uključi-isključi offline prijatelje.")
+
+msgid(FILTER_TO_ALL)
+msgstr("Prikaži sve kontakte!")
+
+msgid(FILTER_TO_ONLINE)
+msgstr("Prikaži samo nazočne prijatelje!")
+
+msgid(ADD)
+msgstr("Dodaj")
+
+msgid(CREATEGROUPCHAT)
+msgstr("Stvori grupni chat")
+
+msgid(SWITCHPROFILE)
+msgstr("Zamijeni profil")
+
+msgid(FRIENDREQUEST)
+msgstr("Zahtjev za prijateljstvom")
+
+msgid(USERSETTINGS)
+msgstr("Postavke")
+
+msgid(FRIEND_SETTINGS)
+msgstr("Postavke prijatelja")
+
+msgid(NAME)
+msgstr("Ime")
+
+msgid(PROFILE)
+msgstr("Profil")
+
+msgid(STATUSMESSAGE)
+msgstr("Statusna poruka")
+
+msgid(PREVIEW)
+msgstr("Pregled")
+
+msgid(DEVICESELECTION)
+msgstr("Biranje uređaja")
+
+msgid(AUDIOINPUTDEVICE)
+msgstr("Ulazni audio uređaj")
+
+msgid(AUDIOFILTERING)
+msgstr("Audio filtriranje")
+
+msgid(AUDIOOUTPUTDEVICE)
+msgstr("Izlazni audio uređaj")
+
+msgid(VIDEOINPUTDEVICE)
+msgstr("Ulazni video uređaj")
+
+msgid(PUSH_TO_TALK)
+msgstr("Stisni za govor")
+
+msgid(STATUS_ONLINE)
+msgstr("Nazočan")
+
+msgid(STATUS_AWAY)
+msgstr("Odsutan")
+
+msgstr("Zauzet")
+msgid(STATUS_BUSY)
+
+msgid(NOT_CONNECTED)
+msgstr("Nije spojen")
+
+msgid(OTHERSETTINGS)
+msgstr("Ostale postavke")
+
+msgid(USER_INTERFACE)
+msgstr("Sučelje")
+
+msgid(UTOX_SETTINGS)
+msgstr("Postavke")
+
+msgid(NETWORK_SETTINGS)
+msgstr("Mrežne postavke")
+
+msgid(PROFILE_PASSWORD)
+msgstr("Zaporka")
+
+msgid(LOCK_UTOX)
+msgstr("Odspoji Tox i zaključaj ovaj profil.")
+
+msgid(SHOW_UI_PASSWORD)
+msgstr("Klikni za prikaz zaporke. Promjene se odmah primjenjuju!")
+
+msgid(LOCK)
+msgstr("Zaključaj")
+
+msgid(AUDIO_VIDEO)
+msgstr("Audio/video")
+
+msgid(SAVELOCATION)
+msgstr("Snimi lokaciju")
+
+msgid(LANGUAGE)
+msgstr("Jezik")
+
+msgid(NETWORK)
+msgstr("Mreža")
+
+msgid(WARNING)
+msgstr("Promjena mrežnih/proxy postavki će vas privremeno odspojiti od Tox mreže")
+
+msgid(LOGGING)
+msgstr("Evidencije")
+
+msgid(AUDIONOTIFICATIONS)
+msgstr("Omogući zvučne obavijesti (zvonjenje)")
+
+msgid(RINGTONE)
+msgstr("Zvono")
+
+msgid(IS_TYPING)
+msgstr("piše...")
+
+msgid(CLOSE_TO_TRAY)
+msgstr("Minimiziraj")
+
+msgid(START_IN_TRAY)
+msgstr("Pokreni minimizirano")
+
+msgid(COPY)
+msgstr("Kopiraj")
+
+msgid(COPYWITHOUTNAMES)
+msgstr("Kopiraj (bez imena)")
+
+msgid(COPY_WITH_NAMES)
+msgstr("Kopiraj (uključujući imena)")
+
+msgid(CUT)
+msgstr("Izreži")
+
+msgid(PASTE)
+msgstr("Zalijepi")
+
+msgid(DELETE)
+msgstr("Obriši")
+
+msgid(SELECTALL)
+msgstr("Označi sve")
+
+msgid(REMOVE)
+msgstr("Ukloni")
+
+msgid(REMOVE_FRIEND)
+msgstr("Ukloni prijatelja")
+
+msgid(REMOVE_GROUP)
+msgstr("Ukloni grupu")
+
+msgid(LEAVE)
+msgstr("Izađi")
+
+msgid(LEAVE_GROUP)
+msgstr("Izađi iz grupe")
+
+msgid(CTOPIC)
+msgstr("Promijeni temu")
+
+msgid(ACCEPT)
+msgstr("Prihvati")
+
+msgid(IGNORE)
+msgstr("Ignoriraj")
+
+msgid(SET_ALIAS)
+msgstr("Namjesti alias")
+
+msgid(FRIEND_AUTOACCEPT)
+msgstr("Prihvati dolazne datoteke bez potvrde")
+
+msgid(SENDMESSAGE)
+msgstr("Pošalji poruku")
+
+msgid(SENDSCREENSHOT)
+msgstr("Pošalji snimak ekrana")
+
+msgid(CLICKTOSAVE)
+msgstr("Klikni za snimanje")
+
+msgid(CLICKTOOPEN)
+msgstr("Klikni za otvaranje")
+
+msgid(CANCELLED)
+msgstr("Otkazano")
+
+msgid(DPI_TINY)
+msgstr("Malo (50%)")
+
+msgid(DPI_NORMAL)
+msgstr("Normalno (100%)")
+
+msgid(DPI_BIG)
+msgstr("Povećano (150%)")
+
+msgid(DPI_LARGE)
+msgstr("Veliko (200%)")
+
+msgid(DPI_HUGE)
+msgstr("Ogromno (250%)")
+
+msgid(PROXY_DISABLED)
+msgstr("Onemogućeno")
+
+msgid(PROXY_FALLBACK)
+msgstr("Ako ne radi drugačije")
+
+msgid(PROXY_ALWAYS_USE)
+msgstr("Rabi uvijek")
+
+msgid(NO)
+msgstr("Ne")
+
+msgid(YES)
+msgstr("Da")
+
+msgid(OFF)
+msgstr("Isključeno")
+
+msgid(ON)
+msgstr("Uključeno")
+
+msgid(SHOW)
+msgstr("Prikaži")
+
+msgid(HIDE)
+msgstr("Sakrij")
+
+msgid(VIDEO_IN_NONE)
+msgstr("Nema")
+
+msgid(AUDIO_IN_DEFAULT_LOOPBACK)
+msgstr("Defaultni (loopback) ulaz")
+
+msgid(AUDIO_IN_ANDROID)
+msgstr("OpenSL ulaz")
+
+msgid(DEFAULT_FRIEND_REQUEST_MESSAGE)
+msgstr("Molim prihvatite poziv za prijateljstvom.")
+
+msgid(CONTACT_SEARCH_ADD_HINT)
+msgstr("Traži/dodaj prijatelje")
+
+msgid(WINDOW_TITLE_VIDEO_PREVIEW)
+msgstr("Video pregled")
+
+msgid(MUTE)
+msgstr("Utišaj")
+
+msgid(UNMUTE)
+msgstr("Normalna glasnoća")
+
+msgid(SELECT_AVATAR_TITLE)
+msgstr("Izaberi avatar")
+
+msgid(AVATAR_TOO_LARGE_MAX_SIZE_IS)
+msgstr("Prevelik avatar. Najveća veličina je: ")
+
+msgid(CANT_FIND_FILE_OR_EMPTY)
+msgstr("Nije moguće učitati izabranu datoteku ili je datoteka prazna.")
+
+msgid(CLEAR_HISTORY)
+msgstr("Obriši povijest")
+
+msgid(AUTO_STARTUP)
+msgstr("Pokreni pri podizanju sustava")
+
+msgid(THEME)
+msgstr("Tema")
+
+msgid(THEME_DEFAULT)
+msgstr("Defaultna tema")
+
+msgid(THEME_LIGHT)
+msgstr("Svijetla tema")
+
+msgid(THEME_DARK)
+msgstr("Tamna tema")
+
+msgid(THEME_HIGHCONTRAST)
+msgstr("Visoki kontrast")
+
+msgid(THEME_CUSTOM)
+msgstr("Posebno (vidi upute)")
+
+msgid(SEND_TYPING_NOTIFICATIONS)
+msgstr("Šalji obavijesti o tipkanju")

--- a/src/ui_i18n.h
+++ b/src/ui_i18n.h
@@ -202,3 +202,11 @@ LANG_POSIX_LOCALE("eo")
 #include "../langs/en.h" //fallback to English for untranslated things
 #include "../langs/eo.h"
 #undef _LANG_ID
+
+//"CROATIAN" "hrvatski"
+#define _LANG_ID LANG_HR
+LANG_POSIX_LOCALE("hr_HR")
+LANG_WINDOWS_ID(0x041A)
+#include "../langs/en.h" //fallback to English for untranslated things
+#include "../langs/hr.h"
+#undef _LANG_ID

--- a/src/ui_i18n_decls.h
+++ b/src/ui_i18n_decls.h
@@ -24,7 +24,8 @@ enum {
     LANG_HU,
     LANG_PT,
     LANG_EO,
-
+    LANG_HR,
+    
     NUM_LANGS // add langs before this line
 };
 


### PR DESCRIPTION
There is no sense to install two libs with make install and
other two with checkinstall.

On debian based distros usage of deb packages and tool like checkinstall
is preferred, as manually installing something in /usr/local and later
on upgrade (which will surely happen once)
installing that same package in location like /usr/bin is
a sure way to cause headache until you try using something like:
which binary_name
and then realizing that you have two installs, and you totally
forgot that you four of more years ago tried something and ...

In short, make install isn't BAD, but checkinstall is better.

I know, this is a bit long commit msg, but this is experience
talking, not me. :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grayhatter/utox/249)
<!-- Reviewable:end -->
