### PR TITLE
fix SYSROOT default setting

### DIFF
--- a/tools/build-android.sh
+++ b/tools/build-android.sh
@@ -21,7 +21,7 @@ KEYSTORE=${KEYSTORE-~/.android/utox.keystore}
 # Standard dev kit locations on posix
 ANDROID_NDK_HOME=${ANDROID_NDK_HOME-/opt/android-ndk}
 ANDROID_SDK_HOME=${ANDROID_SDK_HOME-/opt/android-sdk}
-SYSROOT=${SYSROOT-/opt/android-ndk/platforms/${NDK_VERSION}/arch-arm}
+SYSROOT=${SYSROOT-${ANDROID_NDK_HOME}/platforms/${NDK_VERSION}/arch-arm}
 TOOLCHAIN=${TOOLCHAIN-./toolchain}
 AAPT=${AAPT-$ANDROID_SDK_HOME/build-tools/${DEV_VERSION}/aapt}
 


### PR DESCRIPTION
now, it's clear why `-I$SYSROOT/usr/include` 59791f80938d549ca68cac80095859c298ecccbd  is unnecessary...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grayhatter/utox/288)
<!-- Reviewable:end -->
