### PR TITLE
Re-introduced audio filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # set to anything else to disable them
 DBUS 			= 1
 V4LCONVERT 		= 1
-FILTER_AUDIO 	= 0
+FILTER_AUDIO 	= 1
 UNITY 			= 0
 XP 				= 0
 


### PR DESCRIPTION
As mentioned by @Garve, audio filtering was disabled in the latest version of uTox.
This closes #363.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grayhatter/utox/364)
<!-- Reviewable:end -->
